### PR TITLE
Resolve .bat file conflict using direct command execution

### DIFF
--- a/magritte/magritte_graph.bzl
+++ b/magritte/magritte_graph.bzl
@@ -161,21 +161,16 @@ def _copy_action_bash(ctx, input_file, output_file):
 # Copies a file to another file. If the destination directory does not exist
 # it will be created. (Windows version)
 def _copy_action_windows(ctx, input_file, output_file):
-    bat = ctx.actions.declare_file(ctx.label.name + "_cmd.bat")
     file_to_copy = input_file.path.replace("/", "\\")
     destination_folder = output_file.dirname.replace("/", "\\")
-    ctx.actions.write(
-        output = bat,
-        content = "@mkdir \"%s\"\n@copy /Y \"%s\" \"%s\"" %
-                  (destination_folder, file_to_copy, destination_folder),
-        is_executable = True,
-    )
+    cmd_part1 = "(if not exist \"%s\" mkdir \"%s\")" % (destination_folder, destination_folder)
+    cmd_part2 = " && @copy /Y \"%s\" \"%s\"" % (file_to_copy, destination_folder)
+    cmd = cmd_part1 + cmd_part2
     ctx.actions.run(
         inputs = [input_file],
-        tools = [bat],
         outputs = [output_file],
         executable = "cmd.exe",
-        arguments = ["/C", bat.path.replace("/", "\\")],
+        arguments = ["/C", cmd],
         use_default_shell_env = True,
     )
 


### PR DESCRIPTION
### Resolve .bat File Conflict by Direct Command Execution on Windows

This commit fixes the conflict encountered during the build process on Windows systems. The error was caused by multiple actions attempting to write to the same .bat file.

The solution implemented avoids this conflict by directly executing the necessary commands using cmd.exe, rather than writing to a shared .bat file. This allows actions to be executed independently without conflicting with one another, enabling a smooth build process.

**The change includes:**
- Replacing the .bat file creation and execution with a direct command execution sequence in the _copy_action_windows function.
- Adjusting the related parts of the code to align with the new command execution approach.

For further information, please consult this [issue](https://github.com/google/magritte/issues/17)